### PR TITLE
Extract link regex into module with tests

### DIFF
--- a/link_patterns.py
+++ b/link_patterns.py
@@ -1,0 +1,17 @@
+import re
+
+"""Regular expression patterns for detecting various types of hyperlinks."""
+
+# Pattern to match HTTP and HTTPS URLs. Matches any non-whitespace characters
+# after the protocol to allow for fragments, query parameters and unusual
+# path characters.
+URL_PATTERN = re.compile(r'https?://\S+')
+
+# Pattern to match mailto links.
+MAILTO_PATTERN = re.compile(r'mailto:[^\s>]+')
+
+# Pattern to match FTP links.
+FTP_PATTERN = re.compile(r'ftp://\S+')
+
+# Collection of all available patterns for convenience.
+ALL_PATTERNS = [URL_PATTERN, MAILTO_PATTERN, FTP_PATTERN]

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -1,10 +1,8 @@
-import re
 import streamlit as st
 from docx import Document
 from PyPDF2 import PdfReader
 
-# Define a URL pattern to match hyperlinks
-url_pattern = re.compile(r'http[s]?://(?:[a-zA-Z]|[0-9]|[$-_@.&+]|[!*\\(\\),]|(?:%[0-9a-fA-F][0-9a-fA-F]))+')
+from link_patterns import URL_PATTERN
 
 # Function to extract links from PDFs
 def extract_pdf_links(file):
@@ -32,7 +30,7 @@ def extract_docx_links(file):
             if url:
                 links.append(url)
     for para in doc.paragraphs:
-        links.extend(re.findall(url_pattern, para.text))
+        links.extend(URL_PATTERN.findall(para.text))
     return links
 
 # Streamlit app UI

--- a/tests/test_link_patterns.py
+++ b/tests/test_link_patterns.py
@@ -1,0 +1,23 @@
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+import link_patterns
+
+
+def test_url_with_fragment():
+    text = "See https://example.com/path#section for details"
+    assert link_patterns.URL_PATTERN.findall(text) == ["https://example.com/path#section"]
+
+
+def test_url_with_query_parameters():
+    text = "Search at https://example.com/search?q=openai&lang=en"
+    assert link_patterns.URL_PATTERN.findall(text) == ["https://example.com/search?q=openai&lang=en"]
+
+
+def test_url_with_uncommon_characters():
+    text = "Try https://example.com/~user/file(name)_-+ for more"
+    assert link_patterns.URL_PATTERN.findall(text) == [
+        "https://example.com/~user/file(name)_-+"
+    ]


### PR DESCRIPTION
## Summary
- Add `link_patterns.py` providing reusable regex patterns for HTTP/HTTPS, mailto, and FTP links
- Update Streamlit app to use the shared `URL_PATTERN`
- Add unit tests covering URLs with fragments, query parameters, and uncommon characters

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c8223ed2ec83249d69b02a8000adfa