### PR TITLE
refactor: modularize link extraction

### DIFF
--- a/extractors.py
+++ b/extractors.py
@@ -1,0 +1,59 @@
+"""Functions for extracting hyperlinks from supported document formats."""
+
+from typing import BinaryIO, List
+from docx import Document
+from PyPDF2 import PdfReader
+
+from link_patterns import URL_PATTERN
+
+
+def extract_pdf_links(file: BinaryIO) -> List[str]:
+    """Extract hyperlinks from a PDF file.
+
+    Parameters
+    ----------
+    file: BinaryIO
+        A file-like object containing PDF data.
+
+    Returns
+    -------
+    List[str]
+        A list of extracted URLs from the PDF.
+    """
+    pdf_reader = PdfReader(file)
+    links: List[str] = []
+    for page in pdf_reader.pages:
+        if "/Annots" in page:
+            annotations = page["/Annots"]
+            for annotation in annotations:
+                a_entry = annotation.get_object().get("/A")
+                if isinstance(a_entry, dict):
+                    uri = a_entry.get("/URI")
+                    if uri:
+                        links.append(uri)
+    return links
+
+
+def extract_docx_links(file: BinaryIO) -> List[str]:
+    """Extract hyperlinks from a DOCX file.
+
+    Parameters
+    ----------
+    file: BinaryIO
+        A file-like object containing DOCX data.
+
+    Returns
+    -------
+    List[str]
+        A list of extracted URLs from the DOCX.
+    """
+    doc = Document(file)
+    links: List[str] = []
+    for rel in doc.part.rels.values():
+        if "hyperlink" in rel.reltype:
+            url = rel._target  # type: ignore[attr-defined]
+            if url:
+                links.append(url)
+    for para in doc.paragraphs:
+        links.extend(URL_PATTERN.findall(para.text))
+    return links

--- a/link_patterns.py
+++ b/link_patterns.py
@@ -1,0 +1,5 @@
+"""Regular expression patterns used for link extraction."""
+
+import re
+
+URL_PATTERN = re.compile(r'http[s]?://(?:[a-zA-Z]|[0-9]|[$-_@.&+]|[!*\\(\\),]|(?:%[0-9a-fA-F][0-9a-fA-F]))+')

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -1,48 +1,19 @@
-import re
+"""Streamlit interface for extracting hyperlinks from documents."""
+
 import streamlit as st
-from docx import Document
-from PyPDF2 import PdfReader
 
-# Define a URL pattern to match hyperlinks
-url_pattern = re.compile(r'http[s]?://(?:[a-zA-Z]|[0-9]|[$-_@.&+]|[!*\\(\\),]|(?:%[0-9a-fA-F][0-9a-fA-F]))+')
+from extractors import extract_pdf_links, extract_docx_links
 
-# Function to extract links from PDFs
-def extract_pdf_links(file):
-    pdf_file = PdfReader(file)
-    links = []
-    for page_num in range(len(pdf_file.pages)):
-        page = pdf_file.pages[page_num]
-        if '/Annots' in page:
-            annotations = page['/Annots']
-            for annotation in annotations:
-                a_entry = annotation.get_object().get('/A')
-                if isinstance(a_entry, dict):
-                    uri = a_entry.get('/URI')
-                    if uri:
-                        links.append(uri)
-    return links
-
-# Function to extract links from DOCX files
-def extract_docx_links(file):
-    doc = Document(file)
-    links = []
-    for rel in doc.part.rels.values():
-        if "hyperlink" in rel.reltype:
-            url = rel._target
-            if url:
-                links.append(url)
-    for para in doc.paragraphs:
-        links.extend(re.findall(url_pattern, para.text))
-    return links
 
 # Streamlit app UI
-def main():
+def main() -> None:
+    """Run the Streamlit interface for hyperlink extraction."""
     st.title("Document Link Extractor")
     st.write("Upload a PDF or DOCX file, and this tool will retrieve all the hyperlinks.")
 
     # File uploader for PDF or DOCX
     uploaded_file = st.file_uploader("Choose a PDF or DOCX file", type=['pdf', 'docx'])
-    
+
     if uploaded_file is not None:
         # Check file extension and extract links accordingly
         if uploaded_file.name.endswith('.pdf'):
@@ -64,6 +35,7 @@ def main():
             st.download_button("Download Links as Text File", "\n".join(unique_links), file_name="extracted_links.txt")
         else:
             st.write("No links found in the document.")
+
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
## Summary
- isolate URL regex in `link_patterns.py`
- move DOCX/PDF link extraction to new `extractors.py` with type hints and docs
- streamline `streamlit_app.py` to focus on UI and use new modules

## Testing
- `python -m py_compile streamlit_app.py extractors.py link_patterns.py`


------
https://chatgpt.com/codex/tasks/task_e_68c8224750008324bc287d9d2bfe972c