### PR TITLE
Generate extractor test documents dynamically

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ A lightweight Streamlit app for extracting hyperlinks from PDF and DOCX files.
 - Detects links from PDF annotations and DOCX hyperlink relations or plain text.
 - Deduplicates results and lets you download them as a text file.
 - Runs entirely in the browser via Streamlit.
+- Centralized regex patterns for URLs, mailto, and FTP links.
+- Stops processing encrypted PDFs that cannot be decrypted.
 
 ## Installation
 

--- a/link_patterns.py
+++ b/link_patterns.py
@@ -1,11 +1,14 @@
 import re
 
-"""Regular expression patterns for detecting various types of hyperlinks."""
+"""Regular expression patterns for detecting various types of hyperlinks.
 
-# Pattern to match HTTP and HTTPS URLs. Matches any non-whitespace characters
-# after the protocol to allow for fragments, query parameters and unusual
-# path characters.
-URL_PATTERN = re.compile(r'https?://\S+')
+The URL pattern intentionally excludes common trailing punctuation so that
+links such as ``https://example.com.`` are captured without the final period or
+comma.
+"""
+
+# Pattern to match HTTP and HTTPS URLs while avoiding trailing punctuation.
+URL_PATTERN = re.compile(r"https?://[^\s,]+[^\s.,;:!?)]")
 
 # Pattern to match mailto links.
 MAILTO_PATTERN = re.compile(r'mailto:[^\s>]+')

--- a/pdf_extractor.py
+++ b/pdf_extractor.py
@@ -1,21 +1,17 @@
-import re
 from typing import List
 
 from PyPDF2 import PdfReader, errors
 
-# Regular expression pattern for matching URLs within PDF text
-URL_PATTERN = re.compile(
-    r"http[s]?://(?:[a-zA-Z]|[0-9]|[$-_@.&+]|[!*\\(\\),]|(?:%[0-9a-fA-F][0-9a-fA-F]))+"
-)
+from link_patterns import URL_PATTERN
 
 
 def extract_pdf_links(file) -> List[str]:
     """Extract hyperlinks from a PDF file.
 
     The function scans both annotation dictionaries and visible text objects
-    for links.  Links embedded via annotations (\"/Annots\") are retrieved
+    for links. Links embedded via annotations ("/Annots") are retrieved
     directly, while links present only in the rendered text are located using
-    regular expression matching on the page's extracted text.
+    :data:`link_patterns.URL_PATTERN`.
 
     Parameters
     ----------
@@ -25,14 +21,14 @@ def extract_pdf_links(file) -> List[str]:
     Returns
     -------
     List[str]
-        A list of hyperlinks found within the document.  An empty list is
+        A list of hyperlinks found within the document. An empty list is
         returned if no links are found.
 
     Raises
     ------
     ValueError
-        If the PDF is encrypted and cannot be decrypted or if it is
-        malformed.
+        If the PDF cannot be read or if decryption with an empty password
+        fails.
     """
     links: List[str] = []
     try:
@@ -41,11 +37,13 @@ def extract_pdf_links(file) -> List[str]:
         raise ValueError("Unable to read PDF") from exc
 
     if getattr(reader, "is_encrypted", False):
-        # Attempt to decrypt with an empty password; if it still fails, raise
+        # Attempt to decrypt with an empty password and stop if it fails
         try:
-            reader.decrypt("")
+            result = reader.decrypt("")
         except errors.PdfReadError as exc:
             raise ValueError("Encrypted PDF cannot be decrypted") from exc
+        if result == 0:
+            raise ValueError("Encrypted PDF cannot be decrypted")
 
     for page in reader.pages:
         # Extract links from annotation dictionaries
@@ -62,9 +60,10 @@ def extract_pdf_links(file) -> List[str]:
             text = page.extract_text() or ""
         except Exception:
             text = ""
-        links.extend(re.findall(URL_PATTERN, text))
+        links.extend(URL_PATTERN.findall(text))
 
     return links
 
 
-__all__ = ["extract_pdf_links", "URL_PATTERN"]
+__all__ = ["extract_pdf_links"]
+

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -1,21 +1,28 @@
 import streamlit as st
 from docx import Document
 
-from pdf_extractor import URL_PATTERN, extract_pdf_links
+from link_patterns import URL_PATTERN
+from pdf_extractor import extract_pdf_links
 
 
-# Function to extract links from DOCX files
 def extract_docx_links(file):
+    """Extract hyperlinks from a DOCX file.
+
+    Links are collected from relationship targets and from visible text using
+    :data:`link_patterns.URL_PATTERN`. Duplicate links are removed before
+    returning.
+    """
     doc = Document(file)
     links = []
     for rel in doc.part.rels.values():
         if "hyperlink" in rel.reltype:
-            url = rel._target
+            url = getattr(rel, "target_ref", None)
             if url:
                 links.append(url)
     for para in doc.paragraphs:
         links.extend(URL_PATTERN.findall(para.text))
-    return links
+    # Deduplicate while preserving order
+    return list(dict.fromkeys(links))
 
 # Streamlit app UI
 def main():

--- a/tests/test_extractors.py
+++ b/tests/test_extractors.py
@@ -1,0 +1,107 @@
+import sys
+from io import BytesIO
+from pathlib import Path
+
+import pytest
+from PyPDF2 import PdfReader, PdfWriter
+from docx import Document
+from docx.opc.constants import RELATIONSHIP_TYPE as RT
+from docx.oxml import OxmlElement
+from docx.oxml.ns import qn
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from pdf_extractor import extract_pdf_links
+from streamlit_app import extract_docx_links
+
+
+PDF_HEADER = b"%PDF-1.4\n"
+PDF_STREAM_TEXT = "BT /F1 12 Tf 72 720 Td (Visit https://example.org) Tj ET"
+
+
+def build_sample_pdf_bytes() -> bytes:
+    objects = [
+        "<< /Type /Catalog /Pages 2 0 R >>",
+        "<< /Type /Pages /Kids [3 0 R] /Count 1 >>",
+        "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Resources << /Font << /F1 4 0 R >> >> /Contents 5 0 R /Annots [6 0 R] >>",
+        "<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>",
+        f"<< /Length {len(PDF_STREAM_TEXT)} >>\nstream\n{PDF_STREAM_TEXT}\nendstream",
+        "<< /Type /Annot /Subtype /Link /Rect [72 700 200 720] /Border [0 0 0] /A << /S /URI /URI (https://example.com) >> >>",
+    ]
+
+    body = bytearray()
+    offsets = [0]
+    current = len(PDF_HEADER)
+    for index, obj in enumerate(objects, start=1):
+        obj_bytes = f"{index} 0 obj\n{obj}\nendobj\n".encode("utf-8")
+        offsets.append(current)
+        body.extend(obj_bytes)
+        current += len(obj_bytes)
+
+    xref_offset = len(PDF_HEADER) + len(body)
+    lines = ["xref", f"0 {len(objects) + 1}", "0000000000 65535 f "]
+    for offset in offsets[1:]:
+        lines.append(f"{offset:010} 00000 n ")
+    xref = "\n".join(lines).encode("ascii") + b"\n"
+    trailer = (
+        f"trailer\n<< /Size {len(objects) + 1} /Root 1 0 R >>\nstartxref\n{xref_offset}\n%%EOF\n".encode(
+            "ascii"
+        )
+    )
+    return PDF_HEADER + bytes(body) + xref + trailer
+
+
+def build_encrypted_pdf_bytes() -> bytes:
+    reader = PdfReader(BytesIO(build_sample_pdf_bytes()))
+    writer = PdfWriter()
+    for page in reader.pages:
+        writer.add_page(page)
+    writer.encrypt("secret")
+    buffer = BytesIO()
+    writer.write(buffer)
+    return buffer.getvalue()
+
+
+def add_hyperlink(paragraph, url: str, text: str) -> None:
+    part = paragraph.part
+    rel_id = part.relate_to(url, RT.HYPERLINK, is_external=True)
+    hyperlink = OxmlElement("w:hyperlink")
+    hyperlink.set(qn("r:id"), rel_id)
+
+    run = OxmlElement("w:r")
+    run_properties = OxmlElement("w:rPr")
+    run.append(run_properties)
+    text_element = OxmlElement("w:t")
+    text_element.text = text
+    run.append(text_element)
+    hyperlink.append(run)
+    paragraph._p.append(hyperlink)
+
+
+def build_sample_docx_bytes() -> bytes:
+    document = Document()
+    paragraph = document.add_paragraph("Example link: ")
+    add_hyperlink(paragraph, "https://example.com", "Example")
+    document.add_paragraph("Another https://example.org reference")
+
+    buffer = BytesIO()
+    document.save(buffer)
+    return buffer.getvalue()
+
+
+def test_extract_pdf_links():
+    pdf_file = BytesIO(build_sample_pdf_bytes())
+    links = extract_pdf_links(pdf_file)
+    assert set(links) == {"https://example.com", "https://example.org"}
+
+
+def test_extract_pdf_links_encrypted():
+    encrypted_pdf = BytesIO(build_encrypted_pdf_bytes())
+    with pytest.raises(ValueError):
+        extract_pdf_links(encrypted_pdf)
+
+
+def test_extract_docx_links():
+    docx_file = BytesIO(build_sample_docx_bytes())
+    links = extract_docx_links(docx_file)
+    assert set(links) == {"https://example.com", "https://example.org"}

--- a/tests/test_link_patterns.py
+++ b/tests/test_link_patterns.py
@@ -8,12 +8,16 @@ import link_patterns
 
 def test_url_with_fragment():
     text = "See https://example.com/path#section for details"
-    assert link_patterns.URL_PATTERN.findall(text) == ["https://example.com/path#section"]
+    assert link_patterns.URL_PATTERN.findall(text) == [
+        "https://example.com/path#section"
+    ]
 
 
 def test_url_with_query_parameters():
     text = "Search at https://example.com/search?q=openai&lang=en"
-    assert link_patterns.URL_PATTERN.findall(text) == ["https://example.com/search?q=openai&lang=en"]
+    assert link_patterns.URL_PATTERN.findall(text) == [
+        "https://example.com/search?q=openai&lang=en"
+    ]
 
 
 def test_url_with_uncommon_characters():
@@ -21,3 +25,18 @@ def test_url_with_uncommon_characters():
     assert link_patterns.URL_PATTERN.findall(text) == [
         "https://example.com/~user/file(name)_-+"
     ]
+
+
+def test_mailto_pattern():
+    text = "Contact mailto:user@example.com for help"
+    assert link_patterns.MAILTO_PATTERN.findall(text) == [
+        "mailto:user@example.com"
+    ]
+
+
+def test_ftp_pattern():
+    text = "Fetch ftp://example.com/resource from server"
+    assert link_patterns.FTP_PATTERN.findall(text) == [
+        "ftp://example.com/resource"
+    ]
+


### PR DESCRIPTION
## Summary
- remove committed binary fixtures and replace them with on-the-fly builders used by extractor tests
- craft a minimal PDF in code to validate annotation and text link extraction and encrypt it for failure coverage
- construct DOCX samples programmatically with public hyperlink relationships to verify deduped output

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c824d41bac83248de0d99e94d2ba88